### PR TITLE
Error converting ulid

### DIFF
--- a/custom_components/mediabrowser/__init__.py
+++ b/custom_components/mediabrowser/__init__.py
@@ -50,7 +50,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.bus.async_fire(
             f"{DOMAIN}_{message_type}",
             snake_cased_json(data),
-            context=Context(hub.user_id, parent_id=hub.server_id),
         )
 
     try:


### PR DESCRIPTION
Fixes #2
Recorder integration can't accept unique ids in context longer than 26 characters since HA 2023.4.2

Events pass in the context user_id and server_id which seems to be longer than 26 characters for Jellyfin. 

Resolution: drop user_id and server_id from context, usually they are alredy present in other event fields.