### PR TITLE
Event data for mediabrowser_library_changed

### DIFF
--- a/custom_components/mediabrowser/__init__.py
+++ b/custom_components/mediabrowser/__init__.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
 
 import aiohttp
 from homeassistant.config_entries import (
@@ -12,9 +11,9 @@ from homeassistant.config_entries import (
     ConfigEntryNotReady,
 )
 from homeassistant.const import CONF_URL, Platform
-from homeassistant.core import HomeAssistant, Context
+from homeassistant.core import HomeAssistant
 
-from .helpers import snake_cased_json
+from .helpers import size_of, snake_cased_json
 
 from .const import (
     CONF_CACHE_SERVER_API_KEY,
@@ -23,12 +22,7 @@ from .const import (
     CONF_CACHE_SERVER_PING,
     CONF_CACHE_SERVER_USER_ID,
     CONF_CACHE_SERVER_VERSION,
-    CONF_SENSOR_ITEM_TYPE,
-    CONF_SENSOR_LIBRARY,
-    CONF_SENSOR_USER,
-    CONF_SENSORS,
     DATA_HUB,
-    DATA_POLL_COORDINATOR,
     DOMAIN,
 )
 from .hub import MediaBrowserHub
@@ -46,7 +40,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def async_websocket_message(
         message_type: str, data: dict[str, None] | None
     ) -> None:
-        _LOGGER.debug("%s firing event %s_%s", hub.server_name, DOMAIN, message_type)
+        _LOGGER.debug(
+            "%s firing event %s_%s (%d bytes)",
+            hub.server_name,
+            DOMAIN,
+            message_type,
+            size_of(data),
+        )
         hass.bus.async_fire(
             f"{DOMAIN}_{message_type}",
             snake_cased_json(data),

--- a/custom_components/mediabrowser/const.py
+++ b/custom_components/mediabrowser/const.py
@@ -204,6 +204,7 @@ class Item(StrEnum):
     MBCLIENT = "MediaBrowserClient"
     MEDIA_SOURCE_ID = "MediaSourceId"
     MEDIA_SOURCES = "MediaSources"
+    MEDIA_STREAMS = "MediaStreams"
     MEDIA_TYPE = "MediaType"
     MESSAGE_TYPE = "MessageType"
     NAME = "Name"
@@ -362,6 +363,36 @@ class VirtualFolder(StrEnum):
     YEARS = "years"
 
 
+class UserDataChange(StrEnum):
+    """Keys for UserDataChanged event"""
+
+    USER_ID = "UserId"
+    USER_DATA_LIST = "UserDataList"
+
+
+class LibraryChange(StrEnum):
+    """Keys for LibraryChange event"""
+
+    ITEMS_ADDED = "ItemsAdded"
+    ITEMS_UPDATED = "ItemsUpdated"
+    ITEMS_REMOVED = "ItemsRemoved"
+    FOLDERS_ADDED_TO = "FoldersAddedTo"
+    FOLDERS_REMOVED_FROM = "FoldersRemovedFrom"
+    COLLECTION_FOLDERS = "CollectionFolders"
+
+
+class WebsocketMessage(StrEnum):
+    """Websocket message types"""
+
+    ACTIVITY_LOG_ENTRY = "ActivityLogEntry"
+    FORCE_KEEP_ALIVE = "ForceKeepAlive"
+    KEEP_ALIVE = "KeepAlive"
+    LIBRARY_CHANGED = "LibraryChanged"
+    SCHEDULED_TASK_INFO = "ScheduledTaskInfo"
+    SESSIONS = "Sessions"
+    USER_DATA_CHANGED = "UserDataChanged"
+
+
 class ImageType(StrEnum):
     """Image types."""
 
@@ -454,6 +485,7 @@ class Session(StrEnum):
     PLAYLIST_INDEX = "PlaylistIndex"
     PLAYLIST_LENGTH = "PlaylistLength"
     REMOTE_END_POINT = "RemoteEndPoint"
+    SERVER_ID = "ServerId"
     SUPPORTS_REMOTE_CONTROL = "SupportsRemoteControl"
     SUPPORTED_COMMANDS = "SupportedCommands"
     USER_NAME = "UserName"


### PR DESCRIPTION
Fixes #4

Redesigned events by dropping some information.  At least mediabrowser_library_changed is huge when there are tons of updated in the library. Only first 5 items are now kept.
